### PR TITLE
Fix installation - JavaScript heap out of memory

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -200,18 +200,18 @@ ynh_script_progression --message="Installing Standard Notes - Syncing Server..."
 ynh_use_nodejs
 pushd "$final_path/live/syncing-server-js"
     ynh_print_info "Installing ... [1/3]"
-    ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile
-    ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn build
+    ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn install --pure-lockfile
+    ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn build
 popd
 pushd "$final_path/live/auth"
     ynh_print_info "Installing ... [2/3]"
-    ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile
-    ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn build
+    ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn install --pure-lockfile
+    ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn build
 popd
 pushd "$final_path/live/api-gateway"
     ynh_print_info "Installing ... [3/3]"
-    ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile
-    ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn build
+    ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn install --pure-lockfile
+    ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn build
 popd
 #=================================================
 # INSTALLING Standard Notes - Extensions

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -402,24 +402,24 @@ then
     if [[ "$syncing_server_js_version_installed" < "$syncing_server_js_version" ]]
     then
         pushd "$final_path/live/syncing-server-js"
-            ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile
-            ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn build
+            ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn install --pure-lockfile
+            ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn build
         popd
         ynh_app_setting_set --app=$app --key=syncing_server_js_version --value=$syncing_server_js_version
     fi
     if [[ "$auth_version_installed" < "$auth_version" ]]
     then
         pushd "$final_path/live/auth"
-            ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile
-            ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn build
+            ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn install --pure-lockfile
+            ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn build
         popd
         ynh_app_setting_set --app=$app --key=auth_version --value=$auth_version
     fi
     if [[ "$api_gateway_version_installed" < "$api_gateway_version" ]]
     then
         pushd "$final_path/live/api-gateway"
-            ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn install --pure-lockfile
-            ynh_exec_as $app env PATH=$ynh_node_load_PATH yarn build
+            ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn install --pure-lockfile
+            ynh_exec_as $app env NODE_OPTIONS="--max-old-space-size=4096" PATH=$ynh_node_load_PATH yarn build
         popd
         ynh_app_setting_set --app=$app --key=api_gateway_version --value=$api_gateway_version
     fi


### PR DESCRIPTION
## Problem

- *#36*
- *#38*
- *Install fails -> JavaScript heap out of memory*

## Solution

- *NODE needs more memory during install.*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
